### PR TITLE
Remove rainbow-mode local variable

### DIFF
--- a/yoshi-theme.el
+++ b/yoshi-theme.el
@@ -469,7 +469,3 @@
 
 (provide-theme 'yoshi)
 ;;; yoshi-theme.el ends here
-
-;; Local Variables:
-;; eval: (rainbow-mode 1)
-;; End:


### PR DESCRIPTION
Rather than try to evaluate possibly unsafe code as local variables, you can [do this in your own config like this](https://github.com/purcell/emacs.d/blob/master/lisp/init-lisp.el#L253-L258).
